### PR TITLE
propose change for reading customized r5 jar path

### DIFF
--- a/cal_ttm_bike.py
+++ b/cal_ttm_bike.py
@@ -15,13 +15,20 @@ with open(config_file, "r") as jsonfile:
 
 print('Set Java path...')
 java_home_path = config["java_path"]
+r5_path = config["r5_path"]
 
 # Set the JAVA_HOME environment variable
 os.environ["JAVA_HOME"] = java_home_path
 print(f"    JAVA_HOME is set to: {os.environ['JAVA_HOME']}")
 
+
 sys.argv.append("--verbose")
+sys.argv.extend([
+    "--r5-classpath",
+    r5_path
+])
 import r5py
+
 
 #build a multimodal transport network given street network
 def build_transportnetwork(data_path, osm_filename):

--- a/ttm_config.json
+++ b/ttm_config.json
@@ -1,5 +1,6 @@
 {
     "java_path" : "/opt/homebrew/Cellar/openjdk@11/11.0.14.1/libexec/openjdk.jdk/Contents/Home",
+    "r5_path" : "https://github.com/conveyal/r5/releases/download/v6.9/r5-v6.9-all.jar",
     "data_path" : "data",
     "osm_filename" : "cook_county_bike_2022.osm.pbf",
     "origin_filename" : "CookCountyCensusBlockCentroids2020_WithLatLong_V02_PD_updated.shp",


### PR DESCRIPTION
pointing to customized r5 path seems relatively straightforward, adding this to the config to allow flexibility. 